### PR TITLE
1. Implements weight bits for sphinx

### DIFF
--- a/oedipus/tests/test_api.py
+++ b/oedipus/tests/test_api.py
@@ -35,6 +35,15 @@ class Biscuit(object):
         }
 
 
+class BiscuitWithWeight(object):
+    """Biscuit with default weights"""
+
+    class SphinxMeta(object):
+        """Search metadata for BiscuitWithWeight"""
+        index = 'biscuit'
+        weights = {'a': 5, 'b': 5}
+
+
 @fudge.patch('sphinxapi.SphinxClient')
 def test_initialization(sphinx_client):
     """S-wide default modes should get set when the SphinxClient is made."""
@@ -88,6 +97,76 @@ def test_single_filter(sphinx_client):
                       b__in=[2, 3],
                       c__gte=4,
                       d__lte=5).raw()
+
+
+@fudge.patch('sphinxapi.SphinxClient')
+def test_weight_one(sphinx_client):
+    """Test a single weight adjustment."""
+    (sphinx_client.expects_call().returns_fake()
+                  .is_a_stub()
+                  .expects('SetFieldWeights').with_args({'a': 1})
+                  .expects('RunQueries')
+                  .returns(no_results))
+    S(Biscuit).weight(a=1).raw()
+
+
+@fudge.patch('sphinxapi.SphinxClient')
+def test_weight_multiple(sphinx_client):
+    """Test a multiple weight adjustment."""
+    (sphinx_client.expects_call().returns_fake()
+                  .is_a_stub()
+                  .expects('SetFieldWeights').with_args({'a': 1, 'b': 2})
+                  .expects('RunQueries')
+                  .returns(no_results))
+    S(Biscuit).weight(a=1, b=2).raw()
+
+
+@fudge.patch('sphinxapi.SphinxClient')
+def test_weight_chaining(sphinx_client):
+    """Tests chaining of weights.
+
+    Multiple calls get squashed into one set of weights.
+
+    """
+    (sphinx_client.expects_call().returns_fake()
+                  .is_a_stub()
+                  .expects('SetFieldWeights').with_args({'a': 1, 'b': 2})
+                  .expects('RunQueries')
+                  .returns(no_results))
+    S(Biscuit).weight(a=1).weight(b=2).raw()
+
+
+@fudge.patch('sphinxapi.SphinxClient')
+def test_weight_chaining_same_item(sphinx_client):
+    """Tests chaining on the same item."""
+    (sphinx_client.expects_call().returns_fake()
+                  .is_a_stub()
+                  .expects('SetFieldWeights').with_args({'a': 2})
+                  .expects('RunQueries')
+                  .returns(no_results))
+    S(Biscuit).weight(a=1).weight(a=2).raw()
+
+
+@fudge.patch('sphinxapi.SphinxClient')
+def test_weights_with_defaults(sphinx_client):
+    """Tests chaining on the same item."""
+    (sphinx_client.expects_call().returns_fake()
+                  .is_a_stub()
+                  .expects('SetFieldWeights').with_args({'a': 5, 'b': 5})
+                  .expects('RunQueries')
+                  .returns(no_results))
+    S(BiscuitWithWeight).raw()
+
+
+@fudge.patch('sphinxapi.SphinxClient')
+def test_weights_with_defaults_and_change(sphinx_client):
+    """Tests chaining on the same item."""
+    (sphinx_client.expects_call().returns_fake()
+                  .is_a_stub()
+                  .expects('SetFieldWeights').with_args({'a': 3, 'b': 5})
+                  .expects('RunQueries')
+                  .returns(no_results))
+    S(BiscuitWithWeight).weight(a=3).raw()
 
 
 @fudge.patch('sphinxapi.SphinxClient')


### PR DESCRIPTION
- creates a min/max range for "valid" weight values
- allows for a SphinxMeta to define default values--in Sphinx if you don't
  define defaults, they're 1
- handles SphinxMeta classes that don't define a weight attribute
- allows you to override those default values--overrides will stomp on
  previous values
- tests testing the added functionality
