### PR TITLE
Fixes NameError for SPHINX_MAX_RESULTS

### DIFF
--- a/oedipus/__init__.py
+++ b/oedipus/__init__.py
@@ -370,9 +370,10 @@ class S(object):
             if self._slice != slice(None, None):
                 start = self._slice.start or 0
                 stop = self._slice.stop
-                sphinx.SetLimits(
-                    start,
-                    SPHINX_MAX_RESULTS if stop is None else (stop - start))
+                max_results = (settings.SPHINX_MAX_RESULTS if stop is None
+                               else (stop - start))
+
+                sphinx.SetLimits(start, max_results)
             # else don't bother settings limits
         else:  # self._slice is a number.
             sphinx.SetLimits(self._slice, 1)

--- a/oedipus/tests/test_misc.py
+++ b/oedipus/tests/test_misc.py
@@ -40,3 +40,20 @@ def test_connection_failure(sphinx_client):
                   .is_a_stub()
                   .expects('RunQueries').returns(None))
     assert_raises(SearchError, S(Biscuit)._raw)
+
+
+@fudge.patch('sphinxapi.SphinxClient')
+@fudge.patch('oedipus.settings')
+def test_sphinx_max_results_clips(sphinx_client, settings):
+    """Test SPHINX_MAX_RESULTS affects results."""
+    settings.has_attr(SPHINX_MAX_RESULTS=5)
+    (sphinx_client.expects_call().returns_fake()
+                  .is_a_stub()
+                  .expects('SetLimits').with_args(0, 5)
+                  .expects('RunQueries').returns(no_results))
+
+    # SPHINX_MAX_RESULTS only comes into play if there's no
+    # stop in the slice.
+    s = S(Biscuit)[0:]
+    # Do this to trigger the results.
+    s.count()


### PR DESCRIPTION
SPHINX_MAX_RESULTS is defined in settings, so we should access it there.
Also, I moved it out into a variable for legibility.
