### PR TITLE
Smash all filter values down to ints *before* they hit sphinxapi.

### DIFF
--- a/oedipus/__init__.py
+++ b/oedipus/__init__.py
@@ -1,4 +1,4 @@
-import collections
+from collections import Iterable
 import logging
 import re
 import socket
@@ -358,7 +358,7 @@ class S(object):
         """Set a series of filters on a SphinxClient according to some Django ORM-lookup-style key/value pairs."""
         ranges = self._consolidate_ranges(keys_and_values)
         for field, comparator, value in ranges:
-            value = self._apply_filter_mappings(field, value)
+            value = self._filter_value_to_int(field, value)
             if not comparator:
                 sphinx.SetFilter(field, [value], exclude)
             elif comparator == 'in':
@@ -375,16 +375,14 @@ class S(object):
                                  'comparator.' %
                                  (comparator, field, comparator, value))
 
-    def _apply_filter_mappings(self, name, value):
+    def _filter_value_to_int(self, name, value):
         """Apply filter mappings to convert values to int."""
         mappings = getattr(self.meta, 'filter_mapping', {})
-        converter = mappings.get(name, None)
-        if converter:
-            if (isinstance(value, collections.Iterable) and
-                not isinstance(value, basestring)):
-                return map(converter, value)
-            return converter(value)
-        return value
+        converter = mappings.get(name, int)
+        if (isinstance(value, Iterable) and
+            not isinstance(value, basestring)):
+            return map(converter, value)
+        return converter(value)
 
     @staticmethod
     def _sanitize_query(query):

--- a/oedipus/tests/test_filters.py
+++ b/oedipus/tests/test_filters.py
@@ -127,6 +127,21 @@ def test_filter_string_mapping(sphinx_client):
     S(Biscuit).filter(a='test')._raw()
 
 
+def test_bool_mapping():
+    """Booleans should be mashed down into ints by default."""
+    # Fudge doesn't compare harshly enough to make False != 0, so we do this as
+    # a unit test of _filter_value_to_int().
+    s = S(Biscuit)
+    assert s._filter_value_to_int('some_bool', False) is 0
+    assert s._filter_value_to_int('some_bool', True) is 1
+
+    # Make sure the int cast is applied even to members of iterables:
+    array = s._filter_value_to_int('some_bool', [True, False])
+    eq_(type(array[0]), int)
+    eq_(type(array[1]), int)
+    eq_(array, [1, 0])
+
+
 @fudge.patch('sphinxapi.SphinxClient')
 def test_chained_filters_and_excludes(sphinx_client):
     """Test several filter() and exclude() calls ANDed together."""


### PR DESCRIPTION
This lets us pass things like `filter(some_bool=False)` without having to define an explicit mapping for it.

Renamed `_apply_filter_mappings()` because it does more now.

Quick sanity check, willkg?
