### PR TITLE
Fix group_by to handle multiple sort fields

### DIFF
--- a/oedipus/__init__.py
+++ b/oedipus/__init__.py
@@ -254,7 +254,7 @@ class S(object):
 
         :param attribute: The attribute to group on.
         :param groupsort: How the results in the final result set get
-            sorted.  e.g. ``@group``, ``-@group``
+            sorted.  e.g. ``'@group'``, ``'-@group'``, ``('@group', 'age')``
 
         """
         return self._clone(next_step=('group_by', (attribute, groupsort)))
@@ -464,8 +464,11 @@ class S(object):
         sphinx.SetSortMode(sphinxapi.SPH_SORT_EXTENDED, sort)
 
         if group_by is not None:
+            sort_field = group_by[1]
+            if not isinstance(sort_field, (tuple, list)):
+                sort_field = [sort_field]
             sphinx.SetGroupBy(group_by[0], sphinxapi.SPH_GROUPBY_ATTR,
-                              self._extended_sort_fields([group_by[1]]))
+                              self._extended_sort_fields(sort_field))
 
         # set the final set of weights here
         if weights:

--- a/oedipus/tests/test_groupby.py
+++ b/oedipus/tests/test_groupby.py
@@ -51,6 +51,18 @@ def test_group_by_override(sphinx_client):
 
 
 @fudge.patch('sphinxapi.SphinxClient')
+def test_group_by_multiple_bits(sphinx_client):
+    """Test group by with multiple bits."""
+    (sphinx_client.expects_call().returns_fake()
+                  .is_a_stub()
+                  .expects('SetGroupBy')
+                  .with_args('a', sphinxapi.SPH_GROUPBY_ATTR, '@relevance DESC, age ASC')
+                  .expects('RunQueries')
+                  .returns(no_results))
+    S(Biscuit).group_by('a', ('-@relevance', 'age'))._raw()
+
+
+@fudge.patch('sphinxapi.SphinxClient')
 def test_group_by_sphinxmeta(sphinx_client):
     """Test group by from SphinxMeta."""
     (sphinx_client.expects_call().returns_fake()


### PR DESCRIPTION
This fixes group_by to handle multiple sort fields.  So you can now do something like:

```
 S.group_by('a', ('@group', 'age'))
```

The first argument to group_by is the argument to group on and the second is the fields to sort on within that group.  It works a little different than order_by, because of that first argument.

Needed this because discussion_search uses group_by but can potentially sort on multiple fields as defined in `search.__init__:GROUPSORT`.

r?
