### PR TITLE
Fix excerpt problems

### DIFF
--- a/oedipus/__init__.py
+++ b/oedipus/__init__.py
@@ -316,8 +316,8 @@ class S(object):
                 options[mem] = getattr(self.meta, 'excerpt_' + mem)
 
         sphinx = self._sphinx()
-        excerpt = sphinx.BuildExcerpt(docs, self.meta.index, self._query,
-                                      options)
+        excerpt = sphinx.BuildExcerpts(
+            list(docs), self.meta.index, self._query, options)
 
         return excerpt
 

--- a/oedipus/tests/test_excerpt.py
+++ b/oedipus/tests/test_excerpt.py
@@ -124,8 +124,8 @@ class TestExcerpt(BiscuitTestCase):
         (sphinx_client.expects_call()
                       .returns_fake()
                       .is_a_stub()
-                      .expects('BuildExcerpt')
-                      .with_args(('sesame', 'has sesame foo'),
+                      .expects('BuildExcerpts')
+                      .with_args(['sesame', 'has sesame foo'],
                                  'biscuit',
                                  'foo',
                                  {'before_match': '<i>',
@@ -184,8 +184,8 @@ class TestExcerpt(BiscuitTestCase):
         (sphinx_client.expects_call()
                       .returns_fake()
                       .is_a_stub()
-                      .expects('BuildExcerpt')
-                      .with_args(('has sesame foo',),
+                      .expects('BuildExcerpts')
+                      .with_args(['has sesame foo'],
                                  'biscuit',
                                  'foo',
                                  {'before_match': '<i>',


### PR DESCRIPTION
- it's BuildExcerpts and not BuildExcerpt.
- BuildExcerpts expects a list (specifically a list--not a tuple) as the
  first argument.

These minor fixes make excerpting work with the real Slim SphinxClient.

r?
