### PR TITLE
Fix query differences

### DIFF
--- a/oedipus/__init__.py
+++ b/oedipus/__init__.py
@@ -402,6 +402,7 @@ class S(object):
     def _sanitize_query(query):
         """Strip control characters that cause problems."""
         query = re.sub(r'(?<=\S)\-', '\-', query)
+        query = query.replace('/', '\\/')
         return query.replace('^', '').replace('$', '')
 
     def _sphinx(self):
@@ -543,8 +544,9 @@ class S(object):
             if not results:
                 raise SearchError('Sphinx returned no results.')
             if results[0]['status'] == sphinxapi.SEARCHD_ERROR:
-                raise SearchError('Sphinx had an error while performing a '
-                                  'query.')
+                log.error('Sphinx errored while performing a query: %r',
+                          results[0]['error'])
+                return {'matches': []}
 
         # We do only one query at a time; return the first one:
         return self._results_cache[0]

--- a/oedipus/tests/test_misc.py
+++ b/oedipus/tests/test_misc.py
@@ -43,6 +43,18 @@ def test_connection_failure(sphinx_client):
 
 
 @fudge.patch('sphinxapi.SphinxClient')
+def test_query_error(sphinx_client):
+    """[] should get returned when the query has an error."""
+    (sphinx_client.expects_call().returns_fake()
+                  .is_a_stub()
+                  .expects('RunQueries').returns([{
+                    'status': 1,
+                    'warning': '',
+                    'error': 'index questions: syntax error'}]))
+    eq_(S(Biscuit)._raw(), {'matches': []})
+
+
+@fudge.patch('sphinxapi.SphinxClient')
 @fudge.patch('oedipus.settings')
 def test_sphinx_max_results_clips(sphinx_client, settings):
     """Test SPHINX_MAX_RESULTS affects results."""
@@ -57,3 +69,9 @@ def test_sphinx_max_results_clips(sphinx_client, settings):
     s = S(Biscuit)[0:]
     # Do this to trigger the results.
     s.count()
+
+
+def test_sanitize_query():
+    """Tests _sanitize_query."""
+    sq = S._sanitize_query
+    eq_(sq('google.com/iq'), 'google.com\\/iq')


### PR DESCRIPTION
- search.clients ignores Sphinx errors, but oedipus didn't.  This
  changes oedipus to log the error, but return [].
- _sanitize_query wasn't sanitizing /.  This changes oedipus to
  sanitize / as \/.
- Adds tests for the fixes.

This fixed the problem in bug #695667 and also papers the way forward to fixing future syntax issues.

r?
