### PR TITLE
Lots of changes

### DIFF
--- a/oedipus/__init__.py
+++ b/oedipus/__init__.py
@@ -272,11 +272,15 @@ class S(object):
     def count(self):
         """Return the number of hits for the current query.
 
-        Can't avoid hitting the DB if we want accuracy, since Sphinx may
-        contain documents that have since been deleted from the DB.
+        .. Note::
+
+           This tells you the number of docs that match the Sphinx
+           search.  If your Sphinx index is out of sync with your DB,
+           then this won't be accurate.
 
         """
-        return len(self._results())
+        raw = self._raw()
+        return len(raw['matches'])
 
     __len__ = count
 

--- a/oedipus/__init__.py
+++ b/oedipus/__init__.py
@@ -269,6 +269,18 @@ class S(object):
             raise TypeError('values() must be given a list of field names.')
         return self._clone(next_step=('values', fields))
 
+    def object_ids(self):
+        """Returns a list of object ids from Sphinx matches."""
+        raw = self._raw()  # side effect: sets _results_class and _fields
+        results = raw['matches']
+
+        if hasattr(self.meta, 'id_field'):
+            field = self.meta.id_field
+            ids = [r['attrs'][field] for r in results]
+        else:
+            ids = [r['id'] for r in results]
+        return ids
+
     def count(self):
         """Return the number of hits for the current query.
 
@@ -518,14 +530,7 @@ class S(object):
         The result supports len() as well.
 
         """
-        raw = self._raw()  # side effect: sets _results_class and _fields
-        results = raw['matches']
-
-        if hasattr(self.meta, 'id_field'):
-            field = self.meta.id_field
-            ids = [r['attrs'][field] for r in results]
-        else:
-            ids = [r['id'] for r in results]
+        ids = self.object_ids()
         return self._results_class(self.type, ids, self._fields)
 
     def _default_sort(self):

--- a/oedipus/__init__.py
+++ b/oedipus/__init__.py
@@ -274,7 +274,13 @@ class S(object):
         return self._clone(next_step=('values', fields))
 
     def object_ids(self):
-        """Returns a list of object ids from Sphinx matches."""
+        """Returns a list of object ids from Sphinx matches.
+
+        If there's a ``SphinxMeta.id_field``, then this will be the
+        values of that field in the results set.  Otherwise it's the
+        ids in the results set.
+
+        """
         raw = self._raw()  # side effect: sets _results_class and _fields
         results = raw['matches']
 
@@ -538,7 +544,7 @@ class S(object):
         k.
 
         :arg k: Index or slice to retrieve from the results.  Defaults
-            to ``None``.
+            to ``None`` which means you'll get the full results set.
         """
         ids = self.object_ids()
         if k is not None:

--- a/oedipus/__init__.py
+++ b/oedipus/__init__.py
@@ -103,17 +103,21 @@ class S(object):
     def __getitem__(self, k):
         """Do a lazy slice of myself, or return a single item from my results.
 
-        :arg k: If a number, return an actual single result. If a slice, return
-            a new ``S`` with the requested slice bounds taken into account. If
-            my results have already been fetched, return a real list of
-            results, sliced as requested.
+        If ``k`` is a number, then it returns the object at index k.
+        If ``k`` is a slice, return a new ``S`` with the requested
+        slice bounds taken into account.
+
+        If my results have already been fetched, return a real list of
+        results indexed/sliced as requested.
+
+        :arg k: index or slice to retrieve from the results.
 
         Haven't bothered to do the thinking to support slice steps or negative
         slice components yet.
 
         """
         if self._raw_cache is not None:
-            return self._raw_cache[k]
+            return self._results(k)
 
         new = self._clone()
         # Compute a single slice out of any we already have & the new one:
@@ -523,14 +527,22 @@ class S(object):
 
         return sphinx
 
-    def _results(self):
+    def _results(self, k=None):
         """Return an iterable of results in whatever format was picked.
 
         The format is determined by earlier calls to values() or values_dict().
         The result supports len() as well.
 
+        If ``k`` is passed in, then it will restrict the DB query to
+        querying only the objects at index k or in the range of slice
+        k.
+
+        :arg k: Index or slice to retrieve from the results.  Defaults
+            to ``None``.
         """
         ids = self.object_ids()
+        if k is not None:
+            ids = ids[k]
         return self._results_class(self.type, ids, self._fields)
 
     def _default_sort(self):

--- a/oedipus/__init__.py
+++ b/oedipus/__init__.py
@@ -281,7 +281,8 @@ class S(object):
     __len__ = count
 
     def excerpt(self, result):
-        """Take a result and return the excerpt as a string.
+        """Take a result and return the excerpt as a list of
+        unicodes--one for each highlight_field in the order specified.
 
         :raises ExcerptError: Raises an ``ExcerptError`` if ``excerpt``
             was called before results were calculated or if
@@ -318,6 +319,13 @@ class S(object):
         sphinx = self._sphinx()
         excerpt = sphinx.BuildExcerpts(
             list(docs), self.meta.index, self._query, options)
+
+        # We only excerpt one result, so peel it out of the list.
+        excerpt = excerpt[0]
+
+        # TODO: This assumes the data is in utf-8 which it might not
+        # be depending on the backing database configuration.
+        excerpt = [e.decode('utf-8') for e in excerpt]
 
         return excerpt
 

--- a/oedipus/__init__.py
+++ b/oedipus/__init__.py
@@ -66,7 +66,7 @@ class S(object):
         # only if we never expose the resulting S, since it's impossible to do
         # further __getitem__() calls after that.
         self._slice = slice(None, None)
-        self._results_cache = None
+        self._raw_cache = None
         self._highlight_fields = []
         self._highlight_options = {}
         self._query = None
@@ -112,8 +112,8 @@ class S(object):
         slice components yet.
 
         """
-        if self._results_cache is not None:
-            return self._results_cache[k]
+        if self._raw_cache is not None:
+            return self._raw_cache[k]
 
         new = self._clone()
         # Compute a single slice out of any we already have & the new one:
@@ -292,7 +292,7 @@ class S(object):
         # This catches the case where results haven't been calculated.
         # That could happen if the results from one S were used in a
         # call to excerpt on a new S.
-        if self._results_cache is None:
+        if self._raw_cache is None:
             raise ExcerptError(
                 'excerpt called before results have been calculated.')
 
@@ -535,10 +535,10 @@ class S(object):
         this after a SearchError will retry.
 
         """
-        if self._results_cache is None:
+        if self._raw_cache is None:
             sphinx = self._sphinx()
             try:
-                self._results_cache = results = sphinx.RunQueries()
+                self._raw_cache = results = sphinx.RunQueries()
             except socket.timeout:
                 log.error('Query has timed out!')
                 raise SearchError('Query has timed out!')
@@ -557,7 +557,7 @@ class S(object):
                 return {'matches': []}
 
         # We do only one query at a time; return the first one:
-        return self._results_cache[0]
+        return self._raw_cache[0]
 
 
 try:

--- a/oedipus/results.py
+++ b/oedipus/results.py
@@ -21,9 +21,6 @@ class SearchResults(object):
         # Ripped off from elasticutils
         return (self.objects[id] for id in self.ids if id in self.objects)
 
-    def __len__(self):
-        return len(self.objects)
-
 
 class DictResults(SearchResults):
     """Results as an iterable of dictionaries"""

--- a/oedipus/tests/__init__.py
+++ b/oedipus/tests/__init__.py
@@ -70,3 +70,38 @@ class SphinxMockingTestCase(TestCase):
                                  {'attrs': {'color': 4},
                                   'id': 124,
                                   'weight': 10000}]}]))
+
+
+class BigSphinxMockingTestCase(TestCase):
+    """Enforces one call to RunQueries and also makes more biscuits.
+
+    Everyone likes biscuits.
+
+    """
+    def setUp(self):
+        Biscuit(id=100, color='red')
+        Biscuit(id=101, color='orange')
+        Biscuit(id=102, color='yellow')
+        Biscuit(id=103, color='green')
+        Biscuit(id=104, color='blue')
+        Biscuit(id=105, color='indigo')
+        Biscuit(id=106, color='violet')
+
+    def tearDown(self):
+        global model_cache
+        model_cache = []
+
+    def mock_sphinx(self, sphinx_client):
+        matches = [{'attrs': {'color': biscuit.id + 100},
+                    'id': biscuit.id,
+                    'weight': 10000}
+                   for biscuit in model_cache]
+
+        (sphinx_client.expects_call().returns_fake()
+                      .is_a_stub()
+                      .expects('RunQueries')
+                      .times_called(1)
+                      .returns(
+                          [{'status': 0,
+                            'total': len(matches),
+                            'matches': matches}]))

--- a/oedipus/tests/test_getitem.py
+++ b/oedipus/tests/test_getitem.py
@@ -122,7 +122,10 @@ class ConcreteSlicingTestCase(SphinxMockingTestCase):
 class IntegratedSlicesTestCase(BigSphinxMockingTestCase):
     @fudge.patch('sphinxapi.SphinxClient')
     def test_slice_after_len(self, sphinx_client):
-        """Make sure you can slice after len."""
+        """Make sure you can slice after len and that it hits Sphinx
+        only once.
+
+        """
         self.mock_sphinx(sphinx_client)
 
         test_s = S(Biscuit)

--- a/oedipus/tests/test_results.py
+++ b/oedipus/tests/test_results.py
@@ -125,7 +125,7 @@ class ResultsTestCase(SphinxMockingTestCase):
             class SphinxMeta(BaseSphinxMeta):
                 id_field = 'thing_id'
 
-        results = S(FunnyIdBiscuit).values('color').object_ids()
+        results = S(FunnyIdBiscuit).object_ids()
         eq_(results, [123, 124])
 
 

--- a/oedipus/tests/test_results.py
+++ b/oedipus/tests/test_results.py
@@ -94,6 +94,40 @@ class ResultsTestCase(SphinxMockingTestCase):
         results = list(S(FunnyIdBiscuit).values('color'))
         eq_(results, [('red',), ('blue',)])
 
+    @fudge.patch('sphinxapi.SphinxClient')
+    def test_object_ids(self, sphinx_client):
+        """Test object_ids() method."""
+        self.mock_sphinx(sphinx_client)
+
+        results = S(Biscuit).object_ids()
+
+        # Note: The results are dependent on mock_sphinx.  It should
+        # return a list of ids.
+        eq_(results, [123, 124])
+
+    @fudge.patch('sphinxapi.SphinxClient')
+    def test_object_ids_with_id_field(self, sphinx_client):
+        """Test object_ids() method with field_id."""
+        (sphinx_client.expects_call().returns_fake()
+                      .is_a_stub()
+                      .expects('RunQueries').returns(
+                          [{'status': 0,
+                            'total': 2,
+                            'matches':
+                                [{'attrs': {'thing_id': 123},
+                                 'id': 3,
+                                 'weight': 11111},
+                                 {'attrs': {'thing_id': 124},
+                                  'id': 4,
+                                  'weight': 10000}]}]))
+
+        class FunnyIdBiscuit(Biscuit):
+            class SphinxMeta(BaseSphinxMeta):
+                id_field = 'thing_id'
+
+        results = S(FunnyIdBiscuit).values('color').object_ids()
+        eq_(results, [123, 124])
+
 
 def test_object_content_for_fields():
     TestResult = collections.namedtuple('TestResult', ['field1', 'field2'])


### PR DESCRIPTION
- fixes `excerpt` so it's easier to use and decodes contents to unicode
- changes `_results_cache` to `_raw_cache`
- change `__len__` (and `count`) so they operate on the `_raw_cache` rather than `_results()`
- implements `object_ids()` on `S`
- changes `__getitem__` on `S` to slice results (which is what i think it was supposed to do originally anyhow)

I added tests and tweaked the documentation in places, too.

r?
