### PR TITLE
Keep consecutive calls to highlight() with options from updating a previ...

### DIFF
--- a/oedipus/__init__.py
+++ b/oedipus/__init__.py
@@ -485,7 +485,7 @@ class S(object):
             elif action == 'highlight':
                 fields, options = value
                 self._highlight_fields = fields
-                self._highlight_options.update(options)
+                self._highlight_options = options
             elif action == 'exclude':
                 self._set_filters(sphinx, value, exclude=True)
             else:

--- a/oedipus/tests/test_excerpt.py
+++ b/oedipus/tests/test_excerpt.py
@@ -71,8 +71,7 @@ def test_highlight_overrides_previous(sphinx_client):
     # These three are set in the highlight() call.
     eq_(s._highlight_options,
         {'before_match': '<b>',
-         'after_match': '</b>',
-         'limit': 100})
+         'after_match': '</b>'})
     eq_(s._highlight_fields, ('name',))
 
 


### PR DESCRIPTION
...ous S's highlight_options dictionary.

Just noticed this, and I don't think we meant to do it, though the test suggests we did. Did we, and if so, why did we?
