### PR TITLE
Fix object_ids call to be less intense

### DIFF
--- a/oedipus/__init__.py
+++ b/oedipus/__init__.py
@@ -655,7 +655,19 @@ else:
             ids in the results set.
 
             """
+            # We don't want object_ids() to bring back highlighted
+            # stuff ("Just the ids, ma'am."), so we gimp
+            # _build_highlight to do nothing, then do our self.raw(),
+            # then ungimp it. That prevents highlight-related bits
+            # from showing up in the query and results.
+
+            build_highlight = self._build_highlight
+            self._build_highlight = lambda: {}
+
             hits = self.raw()['hits']['hits']
+
+            self._build_highlight = build_highlight
+
             return [int(r['_id']) for r in hits]
 
         def order_by(self, *fields):


### PR DESCRIPTION
Previously, if you had set highlights, then object_ids() would call
raw() and raw() would build a query that included a request for highlighted
stuff and then you'd get a ton of JSON back when all you wanted were
ids.

This code is specific to SUMO and uses code in elasticutils that is
also specific to SUMO. Given that, I'm abusing the freedom to do a
hacky fix where we gimp _build_highlight, call raw(), then ungimp it.
This makes sure no highlight stuff shows up in the query and thus
we don't get highlighted stuff in the returned JSON (and ES doesn't
do all that highlighting work).

For questions, this drops the JSON that comes back from an object_ids call from around 550K to 130K.
